### PR TITLE
Error generating certs with acme v2 and SANs

### DIFF
--- a/extractor.py
+++ b/extractor.py
@@ -42,7 +42,7 @@ class Handler(FileSystemEventHandler):
                     name = c['Domain']['Main']
                     privatekey = c['Key']
                     fullchain = c['Certificate']
-                    sans = c['Domains']['SANs']
+                    sans = c['Domain']['SANs']
 
                 # Decode private key, certificate and chain
                 privatekey = b64decode(privatekey).decode('utf-8')


### PR DESCRIPTION
This error as raised while running : 
```Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.6/site-packages/watchdog/observers/api.py", line 199, in run
    self.dispatch_events(self.event_queue, self.timeout)
  File "/usr/local/lib/python3.6/site-packages/watchdog/observers/api.py", line 368, in dispatch_events
    handler.dispatch(event)
  File "/usr/local/lib/python3.6/site-packages/watchdog/events.py", line 330, in dispatch
    _method_map[event_type](event)
  File "extractor.py", line 13, in on_created
    self.handle(event)
  File "extractor.py", line 48, in handle
    sans = c['Domains']['SANs']
KeyError: 'Domains'
```
Acme.json's file syntax seems to have changed regarding my own traffic acme.json