### PR TITLE
Improving the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN pip3 install -r requirements.txt
 COPY . /app
 
 # Define entrypoint of the app
-ENTRYPOINT ["python3", "-u", "extractor.py"]
+ENTRYPOINT ["python3", "-u", "extractor.py -c data/acme.json -d certs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN pip3 install -r requirements.txt
 COPY . /app
 
 # Define entrypoint of the app
-ENTRYPOINT ["python3", "-u", "extractor.py /data/acme.json /data/certs"]
+ENTRYPOINT ["python3", "-u", "extractor.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN pip3 install -r requirements.txt
 COPY . /app
 
 # Define entrypoint of the app
-ENTRYPOINT ["python3", "-u", "extractor.py -c data/acme.json -d certs"]
+ENTRYPOINT ["python3", "-u", "extractor.py", "-c", "data/acme.json", "-d", "certs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN pip3 install -r requirements.txt
 COPY . /app
 
 # Define entrypoint of the app
-ENTRYPOINT ["python3", "-u", "extractor.py"]
+ENTRYPOINT ["python3", "-u", "extractor.py /data/acme.json /data/certs"]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Traefik Certificate Extractor
 
-Forked from [DanielHuisman/traefik-certificate-extractor](https://github.com/DanielHuisman/traefik-certificate-extractor)
-
 Tool to extract Let's Encrypt certificates from Traefik's ACME storage file. Can automatically restart containers using the docker API.
 
 ## Installation
 ```shell
-git clone https://github.com/snowmb/traefik-certificate-extractor
+git clone https://github.com/DanielHuisman/traefik-certificate-extractor
 cd traefik-certificate-extractor
 ```
 
@@ -36,17 +34,17 @@ optional arguments:
 Default file is `./data/acme.json`. The output directories are `./certs` and `./certs_flat`.
 
 ## Docker
-There is a Docker image available for this tool: [snowmb/traefik-certificate-extractor](https://hub.docker.com/r/snowmb/traefik-certificate-extractor/).
+There is a Docker image available for this tool: [DanielHuisman/traefik-certificate-extractor](https://hub.docker.com/r/DanielHuisman/traefik-certificate-extractor/).
 Example run:
 ```shell
 docker run --name extractor -d \
   -v /opt/traefik:/app/data \
   -v ./certs:/app/certs \
   -v /var/run/docker.socket:/var/run/docker.socket \
-  snowmb/traefik-certificate-extractor 
+  DanielHuisman/traefik-certificate-extractor 
 ```
 Mount the whole folder containing the traefik certificate file (`acme.json`) as `/app/data`. The extracted certificates are going to be written to `/app/certs`.
-The docker socket is used to find any containers with this label: `com.github.SnowMB.traefik-certificate-extractor.restart_domain=<DOMAIN>`.
+The docker socket is used to find any containers with this label: `com.github.DanielHuisman.traefik-certificate-extractor.restart_domain=<DOMAIN>`.
 If the domains of an extracted certificate and the restart domain matches, the container is restarted. Multiple domains can be given seperated by `,`.
 
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,35 @@
 # Traefik Certificate Extractor
 
-Tool to extract Let's Encrypt certificates from Traefik's ACME storage file.
+Forked from [DanielHuisman/traefik-certificate-extractor](https://github.com/DanielHuisman/traefik-certificate-extractor)
+
+Tool to extract Let's Encrypt certificates from Traefik's ACME storage file. Can automatically restart containers using the docker API.
 
 ## Installation
 ```
-git clone https://github.com/DanielHuisman/traefik-certificate-extractor
+git clone https://github.com/snowmb/traefik-certificate-extractor
 cd traefik-certificate-extractor
 ```
 
 ## Usage
 ```
-python3 extractor.py [directory]
+python3 extractor.py [FILE]
 ```
-Default directory is `./data`. The output directory is `./certs`.
+Default file is `./data/acme.json`. The output directories are `./certs` and `./certs_flat`.
 
 ## Docker
-There is a Docker image available for this tool: [danielhuisman/traefik-certificate-extractor](https://hub.docker.com/r/danielhuisman/traefik-certificate-extractor/).
+There is a Docker image available for this tool: [snowmb/traefik-certificate-extractor](https://hub.docker.com/r/snowmb/traefik-certificate-extractor/).
 Example run:
 ```
-docker run --name extractor -d -v /srv/extractor/data:/app/data -v /srv/extractor/certs:/app/certs danielhuisman/traefik-certificate-extractor
+docker run --name extractor -d \
+  -v /opt/traefik:/app/data \
+  -v ./certs:/app/certs \
+  -v /var/run/docker.socket:/var/run/docker.socket \
+  snowmb/traefik-certificate-extractor
 ```
+Mount the whole folder containing the traefik certificate file as `/app/data`. The extracted certificates are going to be written to `/app/certs`.
+The docker socket is used to find any containers with this label: `com.github.SnowMB.traefik-certificate-extractor.restart_domain=<DOMAIN>`.
+If the domains of an extracted certificate and the restart domain matches, the container is restarted. Multiple domains can be given seperated by `,`.
+
 
 ## Output
 ```

--- a/README.md
+++ b/README.md
@@ -5,21 +5,40 @@ Forked from [DanielHuisman/traefik-certificate-extractor](https://github.com/Dan
 Tool to extract Let's Encrypt certificates from Traefik's ACME storage file. Can automatically restart containers using the docker API.
 
 ## Installation
-```
+```shell
 git clone https://github.com/snowmb/traefik-certificate-extractor
 cd traefik-certificate-extractor
 ```
 
 ## Usage
-```
-python3 extractor.py [FILE]
+```shell
+usage: extractor.py [-h] [-c CERTIFICATE] [-d DIRECTORY] [-f] [-r] [--dry-run]
+                    [--include [INCLUDE [INCLUDE ...]] | --exclude
+                    [EXCLUDE [EXCLUDE ...]]]
+
+Extract traefik letsencrypt certificates.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c CERTIFICATE, --certificate CERTIFICATE
+                        file that contains the traefik certificates (default
+                        acme.json)
+  -d DIRECTORY, --directory DIRECTORY
+                        output folder
+  -f, --flat            outputs all certificates into one folder
+  -r, --restart_container
+                        uses the docker API to restart containers that are
+                        labeled accordingly
+  --dry-run             Don't write files and do not start docker containers.
+  --include [INCLUDE [INCLUDE ...]]
+  --exclude [EXCLUDE [EXCLUDE ...]]
 ```
 Default file is `./data/acme.json`. The output directories are `./certs` and `./certs_flat`.
 
 ## Docker
 There is a Docker image available for this tool: [snowmb/traefik-certificate-extractor](https://hub.docker.com/r/snowmb/traefik-certificate-extractor/).
 Example run:
-```
+```shell
 docker run --name extractor -d \
   -v /opt/traefik:/app/data \
   -v ./certs:/app/certs \

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ docker run --name extractor -d \
   -v /opt/traefik:/app/data \
   -v ./certs:/app/certs \
   -v /var/run/docker.socket:/var/run/docker.socket \
-  snowmb/traefik-certificate-extractor
+  snowmb/traefik-certificate-extractor 
 ```
-Mount the whole folder containing the traefik certificate file as `/app/data`. The extracted certificates are going to be written to `/app/certs`.
+Mount the whole folder containing the traefik certificate file (`acme.json`) as `/app/data`. The extracted certificates are going to be written to `/app/certs`.
 The docker socket is used to find any containers with this label: `com.github.SnowMB.traefik-certificate-extractor.restart_domain=<DOMAIN>`.
 If the domains of an extracted certificate and the restart domain matches, the container is restarted. Multiple domains can be given seperated by `,`.
 

--- a/extractor.py
+++ b/extractor.py
@@ -84,7 +84,7 @@ def restartContainerWithDomain(domain):
 #            c.restart()
 
 
-def createCerts(file):
+def createCerts(file, directory, flat):
     # Read JSON file
     data = json.loads(open(file).read())
 
@@ -116,6 +116,7 @@ def createCerts(file):
         start = fullchain.find('-----BEGIN CERTIFICATE-----', 1)
         cert = fullchain[0:start]
         chain = fullchain[start:]
+
 
         # Create domain directory if it doesn't exist
         directory = 'certs/' + name + '/'
@@ -193,12 +194,12 @@ if __name__ == "__main__":
                         help='outputs all certificates into one folder')
     args = parser.parse_args()
 
-    print('DEBUG: watching path: ' + str(args.FILE))
-    print('DEBUG: output path: ' + str(args.OUTPUT))
+    print('DEBUG: watching path: ' + str(args.certificate))
+    print('DEBUG: output path: ' + str(args.directory))
 
     # Create output directories if it doesn't exist
     try:
-        os.makedirs(args.OUTPUT)
+        os.makedirs(args.directory)
     except OSError as error:
         if error.errno != errno.EEXIST:
             raise
@@ -208,7 +209,7 @@ if __name__ == "__main__":
     observer = Observer()
 
     # Register the directory to watch
-    observer.schedule(event_handler, str(args.FILE.parent))
+    observer.schedule(event_handler, str(Path(args.certificate).parent))
 
     # Main loop to watch the directory
     observer.start()

--- a/extractor.py
+++ b/extractor.py
@@ -81,7 +81,7 @@ def restartContainerWithDomains(domains):
         restartDomains = str.split(c.labels["com.github.SnowMB.traefik-certificate-extractor.restart_domain"], ',')
         if not set(domains).isdisjoint(restartDomains):
             print('restarting container ' + c.id)
-#            c.restart()
+            c.restart()
 
 
 def createCerts(args):
@@ -111,8 +111,8 @@ def createCerts(args):
             privatekey = c['Key']
             fullchain = c['Certificate']
             sans = c['Domain']['SANs']
-        
-        if (len(args.include)>0 and name not in args.include) or (len(args.exclude)>0 and name in args.exclude):
+
+        if (args.include and name not in args.include) or (args.exclude and name in args.exclude):
             continue
 
         # Decode private key, certificate and chain
@@ -145,7 +145,7 @@ def createCerts(args):
                     with (directory / name + '.chain.pem').open('w') as f:
                         f.write(chain)
         else:
-            directory = args.directory / name
+            directory = directory / name
             if not directory.exists():
                 directory.mkdir()
 

--- a/extractor.py
+++ b/extractor.py
@@ -69,7 +69,7 @@ class PathType(object):
         return string
 
 
-#def restartContainerWithDomain(domain):
+def restartContainerWithDomain(domain):
 #    client = docker.from_env()
 #    container = client.containers.list(filters = {"label" : "com.github.SnowMB.traefik-certificate-extractor.restart_domain"})
 #    for c in container:

--- a/extractor.py
+++ b/extractor.py
@@ -3,11 +3,110 @@ import os
 import errno
 import time
 import json
+import docker
+
 from base64 import b64decode
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
+from pathlib import Path
+
+
+def restartContainerWithDomain(domain):
+    client = docker.from_env()
+    container = client.containers.list(filters = {"label" : "com.github.SnowMB.traefik-certificate-extractor.restart_domain"})
+    for c in container:
+#        print(c.labels['com.github.SnowMB.traefik-certificate-extractor.restart_domain'])
+        domains = str.split(c.labels["com.github.SnowMB.traefik-certificate-extractor.restart_domain"], ',')
+        if domain in domains:
+            print('restarting container ' + c.id)
+            c.restart()
+
+
+
+def createCerts(file):
+    # Read JSON file
+    data = json.loads(open(file).read())
+
+    # Determine ACME version
+    acme_version = 2 if 'acme-v02' in data['Account']['Registration']['uri'] else 1
+
+    # Find certificates
+    if acme_version == 1:
+        certs = data['DomainsCertificate']['Certs']
+    elif acme_version == 2:
+        certs = data['Certificates']
+
+    # Loop over all certificates
+    for c in certs:
+        if acme_version == 1:
+            name = c['Certificate']['Domain']
+            privatekey = c['Certificate']['PrivateKey']
+            fullchain = c['Certificate']['Certificate']
+            sans = c['Domains']['SANs']
+        elif acme_version == 2:
+            name = c['Domain']['Main']
+            privatekey = c['Key']
+            fullchain = c['Certificate']
+            sans = c['Domain']['SANs']
+
+        # Decode private key, certificate and chain
+        privatekey = b64decode(privatekey).decode('utf-8')
+        fullchain = b64decode(fullchain).decode('utf-8')
+        start = fullchain.find('-----BEGIN CERTIFICATE-----', 1)
+        cert = fullchain[0:start]
+        chain = fullchain[start:]
+
+        # Create domain directory if it doesn't exist
+        directory = 'certs/' + name + '/'
+        try:
+            os.makedirs(directory)
+        except OSError as error:
+            if error.errno != errno.EEXIST:
+                raise
+
+        # Write private key, certificate and chain to file
+        with open(directory + 'privkey.pem', 'w') as f:
+            f.write(privatekey)
+
+        with open(directory + 'cert.pem', 'w') as f:
+            f.write(cert)
+
+        with open(directory + 'chain.pem', 'w') as f:
+            f.write(chain)
+
+        with open(directory + 'fullchain.pem', 'w') as f:
+            f.write(fullchain)
+
+        # Write private key, certificate and chain to flat files
+        directory = 'certs_flat/'
+
+        with open(directory + name + '.key', 'w') as f:
+            f.write(privatekey)
+        with open(directory + name + '.crt', 'w') as f:
+            f.write(fullchain)
+        with open(directory + name + '.chain.pem', 'w') as f:
+            f.write(chain)
+
+        if sans:
+            for name in sans:
+                 with open(directory + name + '.key', 'w') as f:
+                    f.write(privatekey)
+                 with open(directory + name + '.crt', 'w') as f:
+                    f.write(fullchain)
+                 with open(directory + name + '.chain.pem', 'w') as f:
+                    f.write(chain)
+
+        print('Extracted certificate for: ' + name + (', ' + ', '.join(sans) if sans else ''))
+        restartContainerWithDomain(name)
+
+
+
 
 class Handler(FileSystemEventHandler):
+
+    def __init__(self):
+        self.filename = 'acme.json'
+
     def on_created(self, event):
         self.handle(event)
 
@@ -16,86 +115,24 @@ class Handler(FileSystemEventHandler):
 
     def handle(self, event):
         # Check if it's a JSON file
-        if not event.is_directory and event.src_path.endswith('.json'):
+        print ('DEBUG : event fired')
+        if not event.is_directory and event.src_path.endswith(self.filename):
             print('Certificates changed')
 
-            # Read JSON file
-            data = json.loads(open(event.src_path).read())
+            createCerts(event.src_path)
 
-            # Determine ACME version
-            acme_version = 2 if 'acme-v02' in data['Account']['Registration']['uri'] else 1
-
-            # Find certificates
-            if acme_version == 1:
-                certs = data['DomainsCertificate']['Certs']
-            elif acme_version == 2:
-                certs = data['Certificates']
-
-            # Loop over all certificates
-            for c in certs:
-                if acme_version == 1:
-                    name = c['Certificate']['Domain']
-                    privatekey = c['Certificate']['PrivateKey']
-                    fullchain = c['Certificate']['Certificate']
-                    sans = c['Domains']['SANs']
-                elif acme_version == 2:
-                    name = c['Domain']['Main']
-                    privatekey = c['Key']
-                    fullchain = c['Certificate']
-                    sans = c['Domain']['SANs']
-
-                # Decode private key, certificate and chain
-                privatekey = b64decode(privatekey).decode('utf-8')
-                fullchain = b64decode(fullchain).decode('utf-8')
-                start = fullchain.find('-----BEGIN CERTIFICATE-----', 1)
-                cert = fullchain[0:start]
-                chain = fullchain[start:]
-
-                # Create domain directory if it doesn't exist
-                directory = 'certs/' + name + '/'
-                try:
-                    os.makedirs(directory)
-                except OSError as error:
-                    if error.errno != errno.EEXIST:
-                        raise
-
-                # Write private key, certificate and chain to file
-                with open(directory + 'privkey.pem', 'w') as f:
-                    f.write(privatekey)
-
-                with open(directory + 'cert.pem', 'w') as f:
-                    f.write(cert)
-
-                with open(directory + 'chain.pem', 'w') as f:
-                    f.write(chain)
-
-                with open(directory + 'fullchain.pem', 'w') as f:
-                    f.write(fullchain)
-
-                # Write private key, certificate and chain to flat files
-                directory = 'certs_flat/'
-
-                with open(directory + name + '.key', 'w') as f:
-                    f.write(privatekey)
-                with open(directory + name + '.crt', 'w') as f:
-                    f.write(fullchain)
-                with open(directory + name + '.chain.pem', 'w') as f:
-                    f.write(chain)
-
-                if sans:
-                    for name in sans:
-                        with open(directory + name + '.key', 'w') as f:
-                            f.write(privatekey)
-                        with open(directory + name + '.crt', 'w') as f:
-                            f.write(fullchain)
-                        with open(directory + name + '.chain.pem', 'w') as f:
-                            f.write(chain)
-
-                print('Extracted certificate for: ' + name + (', ' + ', '.join(sans) if sans else ''))
 
 if __name__ == "__main__":
     # Determine path to watch
-    path = sys.argv[1] if len(sys.argv) > 1 else './data'
+    val = sys.argv[1] if len(sys.argv) > 1 else './data/acme.json'
+
+    path = Path(val)
+
+    if not path.exists() or path.is_dir():
+        print ('ERROR ' + str(path) + ' does not exist.')
+        sys.exit(1)
+
+    print('watching path: ' + str(path))
 
     # Create output directories if it doesn't exist
     try:
@@ -109,12 +146,15 @@ if __name__ == "__main__":
         if error.errno != errno.EEXIST:
             raise
 
+
+
     # Create event handler and observer
     event_handler = Handler()
+    event_handler.filename = str(path.name)
     observer = Observer()
 
     # Register the directory to watch
-    observer.schedule(event_handler, path)
+    observer.schedule(event_handler, str(path.parent))
 
     # Main loop to watch the directory
     observer.start()

--- a/extractor.py
+++ b/extractor.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
     parser.add_argument('-f', '--flat', action='store_true',
                         help='outputs all certificates into one folder')
     parser.add_argument('-r', '--restart_container', action='store_true',
-                        help='uses the docker API to restart containers that are labeled accordingly')
+                        help="uses the docker API to restart containers that are labeled with 'com.github.SnowMB.traefik-certificate-extractor.restart_domain=<DOMAIN>' if the domain name of a generated certificates matches. Multiple domains can be seperated by ','")
     parser.add_argument('--dry-run', action='store_true', dest='dry',
                         help="Don't write files and do not start docker containers.")
     group = parser.add_mutually_exclusive_group()

--- a/extractor.py
+++ b/extractor.py
@@ -204,6 +204,7 @@ class Handler(FileSystemEventHandler):
 
         with self.lock:
             self.isWaiting = False
+	print('DEBUG : finished')
 
 
 if __name__ == "__main__":

--- a/extractor.py
+++ b/extractor.py
@@ -3,7 +3,7 @@ import os
 import errno
 import time
 import json
-#import docker
+import docker
 import argparse
 from argparse import ArgumentTypeError as err
 from base64 import b64decode
@@ -73,14 +73,14 @@ class PathType(object):
         return string
 
 
-def restartContainerWithDomain(domains):
+def restartContainerWithDomains(domains):
     client = docker.from_env()
     container = client.containers.list(filters = {"label" : "com.github.SnowMB.traefik-certificate-extractor.restart_domain"})
     for c in container:
         restartDomains = str.split(c.labels["com.github.SnowMB.traefik-certificate-extractor.restart_domain"], ',')
-        if not domains.isdisjoint(restartDomains):
+        if not set(domains).isdisjoint(restartDomains):
             print('restarting container ' + c.id)
-            c.restart()
+#            c.restart()
 
 
 def createCerts(file, directory, flat):

--- a/extractor.py
+++ b/extractor.py
@@ -11,6 +11,7 @@ from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 from pathlib import Path
 
+
 class PathType(object):
     def __init__(self, exists=True, type='file', dash_ok=True):
         '''exists:
@@ -22,42 +23,45 @@ class PathType(object):
            dash_ok: whether to allow "-" as stdin/stdout'''
 
         assert exists in (True, False, None)
-        assert type in ('file','dir','symlink',None) or hasattr(type,'__call__')
+        assert type in ('file', 'dir', 'symlink',
+                        None) or hasattr(type, '__call__')
 
         self._exists = exists
         self._type = type
         self._dash_ok = dash_ok
 
     def __call__(self, string):
-        if string=='-':
+        if string == '-':
             # the special argument "-" means sys.std{in,out}
             if self._type == 'dir':
-                raise err('standard input/output (-) not allowed as directory path')
+                raise err(
+                    'standard input/output (-) not allowed as directory path')
             elif self._type == 'symlink':
-                raise err('standard input/output (-) not allowed as symlink path')
+                raise err(
+                    'standard input/output (-) not allowed as symlink path')
             elif not self._dash_ok:
                 raise err('standard input/output (-) not allowed')
         else:
             e = os.path.exists(string)
-            if self._exists==True:
+            if self._exists == True:
                 if not e:
                     raise err("path does not exist: '%s'" % string)
 
                 if self._type is None:
                     pass
-                elif self._type=='file':
+                elif self._type == 'file':
                     if not os.path.isfile(string):
                         raise err("path is not a file: '%s'" % string)
-                elif self._type=='symlink':
+                elif self._type == 'symlink':
                     if not os.path.symlink(string):
                         raise err("path is not a symlink: '%s'" % string)
-                elif self._type=='dir':
+                elif self._type == 'dir':
                     if not os.path.isdir(string):
                         raise err("path is not a directory: '%s'" % string)
                 elif not self._type(string):
                     raise err("path not valid: '%s'" % string)
             else:
-                if self._exists==False and e:
+                if self._exists == False and e:
                     raise err("path exists: '%s'" % string)
 
                 p = os.path.dirname(os.path.normpath(string)) or '.'
@@ -70,6 +74,7 @@ class PathType(object):
 
 
 def restartContainerWithDomain(domain):
+    return
 #    client = docker.from_env()
 #    container = client.containers.list(filters = {"label" : "com.github.SnowMB.traefik-certificate-extractor.restart_domain"})
 #    for c in container:
@@ -77,7 +82,6 @@ def restartContainerWithDomain(domain):
 #        if domain in domains:
 #            print('restarting container ' + c.id)
 #            c.restart()
-
 
 
 def createCerts(file):
@@ -146,17 +150,16 @@ def createCerts(file):
 
         if sans:
             for name in sans:
-                 with open(directory + name + '.key', 'w') as f:
+                with open(directory + name + '.key', 'w') as f:
                     f.write(privatekey)
-                 with open(directory + name + '.crt', 'w') as f:
+                with open(directory + name + '.crt', 'w') as f:
                     f.write(fullchain)
-                 with open(directory + name + '.chain.pem', 'w') as f:
+                with open(directory + name + '.chain.pem', 'w') as f:
                     f.write(chain)
 
-        print('Extracted certificate for: ' + name + (', ' + ', '.join(sans) if sans else ''))
+        print('Extracted certificate for: ' + name +
+              (', ' + ', '.join(sans) if sans else ''))
         restartContainerWithDomain(name)
-
-
 
 
 class Handler(FileSystemEventHandler):
@@ -172,7 +175,7 @@ class Handler(FileSystemEventHandler):
 
     def handle(self, event):
         # Check if it's a JSON file
-        print ('DEBUG : event fired')
+        print('DEBUG : event fired')
         if not event.is_directory and event.src_path.endswith(str(self.args.FILE)):
             print('Certificates changed')
 
@@ -180,10 +183,14 @@ class Handler(FileSystemEventHandler):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Extract traefik letsencrypt certificates.')
-    parser.add_argument('FILE', nargs='?', default='acme.json', type= PathType(exists=True), help='file that contains the traefik certificates (default acme.json)')
-    parser.add_argument('OUTPUT', nargs='?', default='.', type=PathType(type='dir'), help='output folder')
-    parser.add_argument('-f', '--flat',action='store_true', help='outputs all certificates into one folder')
+    parser = argparse.ArgumentParser(
+        description='Extract traefik letsencrypt certificates.')
+    parser.add_argument('FILE', nargs='?', default='acme.json', type=PathType(
+        exists=True), help='file that contains the traefik certificates (default acme.json)')
+    parser.add_argument('OUTPUT', nargs='?', default='.',
+                        type=PathType(type='dir'), help='output folder')
+    parser.add_argument('-f', '--flat', action='store_true',
+                        help='outputs all certificates into one folder')
     args = parser.parse_args()
 
     print('DEBUG: watching path: ' + str(args.FILE))
@@ -195,8 +202,6 @@ if __name__ == "__main__":
     except OSError as error:
         if error.errno != errno.EEXIST:
             raise
-
-
 
     # Create event handler and observer
     event_handler = Handler(args)

--- a/extractor.py
+++ b/extractor.py
@@ -195,7 +195,7 @@ class Handler(FileSystemEventHandler):
                     self.isWaiting = True #trigger the work just once (multiple events get fired)
                     self.timer = threading.Timer(2, self.doTheWork)
                     self.timer.start()
-    
+
     def doTheWork(self):
         print('DEBUG : starting the work')
         domains = createCerts(self.args)
@@ -204,7 +204,7 @@ class Handler(FileSystemEventHandler):
 
         with self.lock:
             self.isWaiting = False
-	print('DEBUG : finished')
+        print('DEBUG : finished')
 
 
 if __name__ == "__main__":

--- a/extractor.py
+++ b/extractor.py
@@ -185,9 +185,9 @@ class Handler(FileSystemEventHandler):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Extract traefik letsencrypt certificates.')
-    parser.add_argument('FILE', nargs='?', default='acme.json', type=PathType(
+    parser.add_argument('-c', '--certificate', default='acme.json', type=PathType(
         exists=True), help='file that contains the traefik certificates (default acme.json)')
-    parser.add_argument('OUTPUT', nargs='?', default='.',
+    parser.add_argument('-d', '--directory', default='.',
                         type=PathType(type='dir'), help='output folder')
     parser.add_argument('-f', '--flat', action='store_true',
                         help='outputs all certificates into one folder')

--- a/extractor.py
+++ b/extractor.py
@@ -76,9 +76,9 @@ class PathType(object):
 
 def restartContainerWithDomains(domains):
     client = docker.from_env()
-    container = client.containers.list(filters = {"label" : "com.github.SnowMB.traefik-certificate-extractor.restart_domain"})
+    container = client.containers.list(filters = {"label" : "com.github.DanielHuisman.traefik-certificate-extractor.restart_domain"})
     for c in container:
-        restartDomains = str.split(c.labels["com.github.SnowMB.traefik-certificate-extractor.restart_domain"], ',')
+        restartDomains = str.split(c.labels["com.github.DanielHuisman.traefik-certificate-extractor.restart_domain"], ',')
         if not set(domains).isdisjoint(restartDomains):
             print('restarting container ' + c.id)
             if not args.dry:
@@ -217,7 +217,7 @@ if __name__ == "__main__":
     parser.add_argument('-f', '--flat', action='store_true',
                         help='outputs all certificates into one folder')
     parser.add_argument('-r', '--restart_container', action='store_true',
-                        help="uses the docker API to restart containers that are labeled with 'com.github.SnowMB.traefik-certificate-extractor.restart_domain=<DOMAIN>' if the domain name of a generated certificates matches. Multiple domains can be seperated by ','")
+                        help="uses the docker API to restart containers that are labeled with 'com.github.DanielHuisman.traefik-certificate-extractor.restart_domain=<DOMAIN>' if the domain name of a generated certificates matches. Multiple domains can be seperated by ','")
     parser.add_argument('--dry-run', action='store_true', dest='dry',
                         help="Don't write files and do not start docker containers.")
     group = parser.add_mutually_exclusive_group()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 watchdog
+docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-watchdog
+watchdog3
 docker


### PR DESCRIPTION
Hey,

I ran into the issue, that I need letsencrypt like certificates for my mailserver, but traefik does not store them in the right format. I found your image and while it does the extracting job quite well, I needed a bit additional functionality.

So I hacked a little bit on the script myself and added / improved the following things:

- added proper command line arguments #3 
  - `-c` `--certs` Certificate file to watch
  - `-d` `--directory` Output directory
- added `--include` and `--exclude` to either restrict the extraction to specific domains or ignore specific domains and take the rest (they are mutally exclusive) #2
- added a small delay (2s) between the event and the actual work, because watchdog would trigger 2-4 times in my tests
- changed the arguments so that only a single file is wachted instead of every `*.json` file in the folder. It can be changed through the command line argument `-c` or `--certs`
- added the python docker API to automatically restart any container that needs to be notified about the certificate change (can be toggled by command line argument `-r` `--restart_container`). It watches for the following label: `com.github.DanielHuisman.traefik-certificate-extractor.restart_domain=<DOMAIN>`. Multiple domains can be seperated by `,`
- added test `-dry-run` option
- split export into normal, letsencrypt style (default) and demoted flat export to a command line option (`--flat`)
- included changes in the Readme

I'm by no means an experienced python programmer, so the code might look a bit messy.

Please use everything as you need. For testing purposes I added an own docker image at [snowmb/traefik-certificate-extractor](https://hub.docker.com/r/snowmb/traefik-certificate-extractor/) with a different label.